### PR TITLE
Fix 'too many values to unpack' issue

### DIFF
--- a/abp_import.py
+++ b/abp_import.py
@@ -51,7 +51,10 @@ def translate(line):
     elif line.startswith("@@"):
         unblock.append(line[2:])
     elif '$' in line:
-        pat, opts = line.split("$",2) 
+        if '$$' in line:
+            pat, opts = line.split("$$",2) 
+        else:
+            pat, opts = line.split("$",2) 
         opts = opts.split(',')
         for opt in opts:
             if opt in "third-party|~third-party|script|image":


### PR DESCRIPTION
Line 12119 of EasyList (24 Jan 2013 21:51 UTC) contains the following (excuse 
the unfortunate vulgarity!):

```
||judgeporn.com/video_pop.php?$$image,~image,popup
```

This is tripping up abp_import.py, giving the following stack trace:

```
Unhandled options: ~image, popup
```

   Traceback (most recent call last):
     File "./abp_import.py", line 101, in <module>
       main()
     File "./abp_import.py", line 98, in main
       print translate_all(easylist, infile)
     File "./abp_import.py", line 71, in translate_all
       str += translate(line)
     File "./abp_import.py", line 54, in translate
       pat, opts = line.split("$",2)
   ValueError: too many values to unpack
   make: **\* [privoxy/easylist.action] Error 1
   ==> ERROR: A failure occurred in build().
       Aborting...
   The build failed.

This is a quick fix that simply checks for "$$" and splits accordingly.
