### PR TITLE
Fix 'issue 11: too many values to unpack'

### DIFF
--- a/abp_import.py
+++ b/abp_import.py
@@ -51,7 +51,7 @@ def translate(line):
     elif line.startswith("@@"):
         unblock.append(line[2:])
     elif '$' in line:
-        pat, opts = line.split("$",2) 
+        pat, opts = line.rsplit("$",1)
         opts = opts.split(',')
         for opt in opts:
             if opt in "third-party|~third-party|script|image":


### PR DESCRIPTION
Line 33048 of easylist (2015-05-09 18:54 UTC) has:

```
/http://[a-zA-Z0-9-]+\.[a-z]+\/.*(?:[!"#$%&'()*+,:;<=>?@/\^_`{|}~-])/$script,third-party,xmlhttprequest,domain=247wallst.com|activistpost.com|alfonzorachel.com|allenbwest.com|allenwestrepublic.com|americanlivewire.com|askmefast.com|barbwire.com|blacklistednews.com|breathecast.com|brosome.com|bulletsfirst.net|chacha.com|cheezburger.com|christianpost.com|christiantoday.com|cinemablend.com|clashdaily.com|classicalite.com|comicallyincorrect.com|comicbookmovie.com|conservativebyte.com|conservativevideos.com|cowboybyte.com|crossmap.com|dailycaller.com|dailysurge.com|dccrimestories.com|dealbreaker.com|designntrend.com|digitaljournal.com|drhotze.com|gamerant.com|genfringe.com|girlsjustwannahaveguns.com|hallels.com|hellou.co.uk|hngn.com|infowars.com|instigatornews.com|investmentwatchblog.com|joblo.com|joeforamerica.com|kdramastars.com|kpopstarz.com|latinpost.com|libertyunyielding.com|listverse.com|makeuseof.com|mensfitness.com|minutemennews.com|moddb.com|mstarz.com|muscleandfitness.com|musictimes.com|naturalnews.com|natureworldnews.com|newser.com|oddee.com|okmagazine.com|opposingviews.com|patriotoutdoornews.com|patriotupdate.com|pitgrit.com|politicususa.com|product-reviews.net|radaronline.com|realfarmacy.com|redmaryland.com|screenrant.com|shark-tank.com|stevedeace.com|techtimes.com|theblacksphere.net|theblaze.com|thefreedictionary.com|thegatewaypundit.com|theladbible.com|thelibertarianrepublic.com|themattwalshblog.com|townhall.com|unilad.co.uk|uniladmag.com|unitrending.co.uk|valuewalk.com|vcpost.com|victoriajackson.com|viralnova.com|whatculture.com|wimp.com|wwitv.com
```

There are two seperate `$`'s in that rule which causes abp_import.py to error out with:

Traceback (most recent call last):
  File "./abp_import.py", line 101, in <module>
    main()
  File "./abp_import.py", line 98, in main
    print translate_all(easylist, infile)
  File "./abp_import.py", line 71, in translate_all
    str += translate(line)
  File "./abp_import.py", line 54, in translate
    pat, opts = line.split("$",2)
ValueError: too many values to unpack
Makefile:18: recipe for target 'privoxy/easylist.action' failed
make: **\* [privoxy/easylist.action] Error 1

This fix splits on the last occurence of `$`. It also makes sure that the max
possible values returned by line.split() is two, so that the first occurrence
of $ won't get split.

Fixes #11
